### PR TITLE
Avoid an infinity loop in LineObserver()

### DIFF
--- a/AmiClient.Observable.cs
+++ b/AmiClient.Observable.cs
@@ -78,7 +78,7 @@ namespace Ami
 				this.Unsubscribe(observer);
 			}
 
-			this.processing = false;
+			this.IsProcessing = false;
 		}
 
 		private sealed class Subscription : IDisposable

--- a/AmiClient.cs
+++ b/AmiClient.cs
@@ -205,8 +205,8 @@ namespace Ami
 					try
 					{
 						await lineObserver
-						     .TakeUntil(line => line.SequenceEqual(AmiMessage.TerminatorBytes))
-						     .Do(line => payload = payload.Append(line));
+							 .TakeUntil(line => line.SequenceEqual(AmiMessage.TerminatorBytes))
+							 .Do(line => payload = payload.Append(line));
 					}
 					catch (InvalidOperationException)
 					{


### PR DESCRIPTION
Currently if somehow terminator bytes haven't been found in the buffer, the function just continues the outer loop, but it can't acquire more because the buffer isn't empty. So we must first try to acquire bytes and if we get nothing then we will just replace the buffer with an empty byte array. Or else we will have a chance to find terminator bytes this time.

P. S. This project really lacks tests.
Also, why there is no .sln file in the repo? It is really hard to add a tests project to the repo without a .sln file.
And is there a particular reason for a such code style (tabs instead of spaces, this.something to access member variables, Int32 instead of int, etc)?