### PR TITLE
#18: Optimize reading and parsing events

### DIFF
--- a/AmiClient.Events.cs
+++ b/AmiClient.Events.cs
@@ -35,10 +35,16 @@ namespace Ami
         public sealed class DataEventArgs : EventArgs
         {
             public readonly Byte[] Data;
+            public readonly AmiMessage AmiMessage;
 
             internal DataEventArgs(Byte[] data)
             {
                 this.Data = data;
+            }
+            
+            internal DataEventArgs(AmiMessage amiMessage)
+            {
+                this.AmiMessage = amiMessage;
             }
         }
 

--- a/AmiClient.csproj
+++ b/AmiClient.csproj
@@ -17,7 +17,7 @@
     <PackageProjectUrl>https://github.com/alexforster/AmiClient</PackageProjectUrl>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8</LangVersion>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\Debug\</OutputPath>


### PR DESCRIPTION
Fix of issue #18
* add a concurrent queue with two worker threads
* EventReader: reads incoming events from stream and enqueues them
* EventWorker: dequeues events and parses them into a AmiMessage
* DataEventArgs is extended to directly retrieve the parsed AmiMessage (no additional parsing needed)
* But this also removes the use of Reactive Extensions