### PR TITLE
When double has a separator, it may cause ArgumentOutOfRangeException

### DIFF
--- a/AmiMessage.cs
+++ b/AmiMessage.cs
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+using System.Globalization;
+
 namespace Ami
 {
     using System;
@@ -90,7 +92,7 @@ namespace Ami
 
                 if(key.Equals("Timestamp", StringComparison.OrdinalIgnoreCase))
                 {
-                    if(Double.TryParse(value, out var seconds))
+                    if(Double.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out var seconds))
                     {
                         var dt = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
                         this.Timestamp = dt.AddSeconds(seconds);


### PR DESCRIPTION
If asterisk reports a Timestamp with a value with a separator, it may cause an error in the conversion (if you are using the application in a Windows environment, the system's regional settings affect the conversion). Example: when converting the string "1708469396.756", the value can be converted to 1708469396756, and when calling .AddSeconds passing this value, ArgumentOutOfRangeException will be generated.